### PR TITLE
Refactoring the signatures

### DIFF
--- a/src/main/java/com/iexec/common/chain/ContributionAuthorization.java
+++ b/src/main/java/com/iexec/common/chain/ContributionAuthorization.java
@@ -1,9 +1,11 @@
 package com.iexec.common.chain;
 
+import com.iexec.common.security.Signature;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.web3j.crypto.Sign;
 
 @Data
 @NoArgsConstructor
@@ -15,7 +17,5 @@ public class ContributionAuthorization {
     private String chainTaskId;
     private String enclave;
 
-    private byte signV;
-    private byte[] signR;
-    private byte[] signS;
+    private Signature signature;
 }

--- a/src/main/java/com/iexec/common/security/Signature.java
+++ b/src/main/java/com/iexec/common/security/Signature.java
@@ -1,9 +1,11 @@
 package com.iexec.common.security;
 
+import com.iexec.common.utils.BytesUtils;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.bouncycastle.util.Arrays;
 
 @Data
 @NoArgsConstructor
@@ -12,8 +14,26 @@ import lombok.NoArgsConstructor;
 public class Signature {
 
     private String walletAddress;
+    private String signature;
 
-    private byte signV;
-    private byte[] signR;
-    private byte[] signS;
+    public Signature(String walletAddress, byte[] sign) {
+        this.walletAddress = walletAddress;
+        this.signature = BytesUtils.bytesToString(sign);
+    }
+
+    public Signature(String walletAddress, byte[] r, byte[] s, byte v) {
+        this(walletAddress, Arrays.concatenate(r, s, new byte[]{v}));
+    }
+
+    public byte[] getR(){
+        return Arrays.copyOfRange(BytesUtils.stringToBytes(signature), 0, 32);
+    }
+
+    public byte[] getS(){
+        return Arrays.copyOfRange(BytesUtils.stringToBytes(signature), 32, 64);
+    }
+
+    public byte getV(){
+        return BytesUtils.stringToBytes(signature)[64];
+    }
 }

--- a/src/main/java/com/iexec/common/security/Signature.java
+++ b/src/main/java/com/iexec/common/security/Signature.java
@@ -14,20 +14,18 @@ import org.web3j.crypto.Sign;
 @Builder
 public class Signature {
 
-    private String walletAddress;
     private String signature;
 
-    public Signature(String walletAddress, byte[] sign) {
-        this.walletAddress = walletAddress;
+    public Signature(byte[] sign) {
         this.signature = BytesUtils.bytesToString(sign);
     }
 
-    public Signature(String walletAddress, byte[] r, byte[] s, byte v) {
-        this(walletAddress, Arrays.concatenate(r, s, new byte[]{v}));
+    public Signature(byte[] r, byte[] s, byte v) {
+        this(Arrays.concatenate(r, s, new byte[]{v}));
     }
 
-    public Signature(String walletAddress, Sign.SignatureData sign) {
-        this(walletAddress, sign.getR(), sign.getS(), sign.getV());
+    public Signature(Sign.SignatureData sign) {
+        this(sign.getR(), sign.getS(), sign.getV());
     }
 
     public byte[] getR(){

--- a/src/main/java/com/iexec/common/security/Signature.java
+++ b/src/main/java/com/iexec/common/security/Signature.java
@@ -15,6 +15,7 @@ import org.web3j.crypto.Sign;
 public class Signature {
 
     // this value is the hexadecimal string of the signature
+    // it is the concatenation of the R, S and V values of the signature.
     private String value;
 
     public Signature(byte[] sign) {

--- a/src/main/java/com/iexec/common/security/Signature.java
+++ b/src/main/java/com/iexec/common/security/Signature.java
@@ -14,10 +14,11 @@ import org.web3j.crypto.Sign;
 @Builder
 public class Signature {
 
-    private String signature;
+    // this value is the hexadecimal string of the signature
+    private String value;
 
     public Signature(byte[] sign) {
-        this.signature = BytesUtils.bytesToString(sign);
+        this.value = BytesUtils.bytesToString(sign);
     }
 
     public Signature(byte[] r, byte[] s, byte v) {
@@ -29,14 +30,14 @@ public class Signature {
     }
 
     public byte[] getR(){
-        return Arrays.copyOfRange(BytesUtils.stringToBytes(signature), 0, 32);
+        return Arrays.copyOfRange(BytesUtils.stringToBytes(value), 0, 32);
     }
 
     public byte[] getS(){
-        return Arrays.copyOfRange(BytesUtils.stringToBytes(signature), 32, 64);
+        return Arrays.copyOfRange(BytesUtils.stringToBytes(value), 32, 64);
     }
 
     public byte getV(){
-        return BytesUtils.stringToBytes(signature)[64];
+        return BytesUtils.stringToBytes(value)[64];
     }
 }

--- a/src/main/java/com/iexec/common/security/Signature.java
+++ b/src/main/java/com/iexec/common/security/Signature.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.bouncycastle.util.Arrays;
+import org.web3j.crypto.Sign;
 
 @Data
 @NoArgsConstructor
@@ -23,6 +24,10 @@ public class Signature {
 
     public Signature(String walletAddress, byte[] r, byte[] s, byte v) {
         this(walletAddress, Arrays.concatenate(r, s, new byte[]{v}));
+    }
+
+    public Signature(String walletAddress, Sign.SignatureData sign) {
+        this(walletAddress, sign.getR(), sign.getS(), sign.getV());
     }
 
     public byte[] getR(){

--- a/src/main/java/com/iexec/common/utils/SignatureUtils.java
+++ b/src/main/java/com/iexec/common/utils/SignatureUtils.java
@@ -41,12 +41,7 @@ public class SignatureUtils {
         byte[] message = Hash.sha3(BytesUtils.stringToBytes(stringToSign));
         Sign.SignatureData sign = Sign.signMessage(message, ecKeyPair, false);
 
-        return Signature.builder()
-                .walletAddress(walletAddress)
-                .signR(sign.getR())
-                .signS(sign.getS())
-                .signV(sign.getV())
-                .build();
+        return new Signature(walletAddress, sign.getR(), sign.getS(), sign.getV());
     }
 
     public static String hashAndSignAsString(String stringToSign, ECKeyPair ecKeyPair) {

--- a/src/main/java/com/iexec/common/utils/SignatureUtils.java
+++ b/src/main/java/com/iexec/common/utils/SignatureUtils.java
@@ -41,7 +41,7 @@ public class SignatureUtils {
         byte[] message = Hash.sha3(BytesUtils.stringToBytes(stringToSign));
         Sign.SignatureData sign = Sign.signMessage(message, ecKeyPair, false);
 
-        return new Signature(walletAddress, sign.getR(), sign.getS(), sign.getV());
+        return new Signature(sign.getR(), sign.getS(), sign.getV());
     }
 
     public static String hashAndSignAsString(String stringToSign, ECKeyPair ecKeyPair) {

--- a/src/test/java/com/iexec/common/security/SignatureTests.java
+++ b/src/test/java/com/iexec/common/security/SignatureTests.java
@@ -9,8 +9,8 @@ public class SignatureTests {
 
     @Test
     public void shouldBeValid() {
-        Signature sign = new Signature(dummyWallet, validSignature);
-        Signature sign2 = new Signature(dummyWallet, sign.getR(), sign.getS(), sign.getV());
+        Signature sign = new Signature(validSignature);
+        Signature sign2 = new Signature(sign.getR(), sign.getS(), sign.getV());
 
 
     }

--- a/src/test/java/com/iexec/common/security/SignatureTests.java
+++ b/src/test/java/com/iexec/common/security/SignatureTests.java
@@ -5,14 +5,11 @@ import org.junit.Test;
 public class SignatureTests {
 
     private String validSignature = "0x1b0b90d9f17a30d42492c8a2f98a24374600729a98d4e0b663a44ed48b589cab0e445eec300245e590150c7d88340d902c27e0d8673f3257cb8393f647d6c75c1b";
-    private String dummyWallet = "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E";
 
     @Test
     public void shouldBeValid() {
         Signature sign = new Signature(validSignature);
         Signature sign2 = new Signature(sign.getR(), sign.getS(), sign.getV());
-
-
     }
 
 }

--- a/src/test/java/com/iexec/common/security/SignatureTests.java
+++ b/src/test/java/com/iexec/common/security/SignatureTests.java
@@ -1,0 +1,18 @@
+package com.iexec.common.security;
+
+import org.junit.Test;
+
+public class SignatureTests {
+
+    private String validSignature = "0x1b0b90d9f17a30d42492c8a2f98a24374600729a98d4e0b663a44ed48b589cab0e445eec300245e590150c7d88340d902c27e0d8673f3257cb8393f647d6c75c1b";
+    private String dummyWallet = "0xabcd1339Ec7e762e639f4887E2bFe5EE8023E23E";
+
+    @Test
+    public void shouldBeValid() {
+        Signature sign = new Signature(dummyWallet, validSignature);
+        Signature sign2 = new Signature(dummyWallet, sign.getR(), sign.getS(), sign.getV());
+
+
+    }
+
+}


### PR DESCRIPTION
Signatures are used in different places in the code, a few structures were redefining the same fields over and over again:
- Signature
- ContributionAutorization
- TeeSignature

Now there is only one class (Signature) handling a string (like the SDK and the PoCo do).
