### PR TITLE
Add `ReplicateStatus#isRunningFailure` method

### DIFF
--- a/src/main/java/com/iexec/common/replicate/ReplicateStatus.java
+++ b/src/main/java/com/iexec/common/replicate/ReplicateStatus.java
@@ -67,7 +67,7 @@ public enum ReplicateStatus {
         return getFailureStatuses().contains(status);
     }
 
-    public static boolean isRunningFailure(ReplicateStatus status) {
+    public static boolean isFailedBeforeComputed(ReplicateStatus status) {
         return status.ordinal() < COMPUTED.ordinal() && getFailureStatuses().contains(status);
     }
 

--- a/src/main/java/com/iexec/common/replicate/ReplicateStatus.java
+++ b/src/main/java/com/iexec/common/replicate/ReplicateStatus.java
@@ -67,6 +67,10 @@ public enum ReplicateStatus {
         return getFailureStatuses().contains(status);
     }
 
+    public static boolean isRunningFailure(ReplicateStatus status) {
+        return status.ordinal() < COMPUTED.ordinal() && getFailureStatuses().contains(status);
+    }
+
     public static boolean isCompletable(ReplicateStatus status) {
         return getCompletableStatuses().contains(status);
     }

--- a/src/test/java/com/iexec/common/replicate/ReplicateStatusTests.java
+++ b/src/test/java/com/iexec/common/replicate/ReplicateStatusTests.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.iexec.common.replicate.ReplicateStatus.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class ReplicateStatusTests {
@@ -58,4 +58,45 @@ public class ReplicateStatusTests {
         assertEquals(missingStatuses.size(), 0);
     }
 
+    @Test
+    void shouldBeRunningFailures() {
+        final List<ReplicateStatus> runningFailures = List.of(
+                START_FAILED,
+                APP_DOWNLOAD_FAILED,
+                DATA_DOWNLOAD_FAILED,
+                COMPUTE_FAILED
+        );
+        final List<ReplicateStatus> notRunningFailures = List.of(
+                CREATED,
+                STARTING,
+                STARTED,
+                APP_DOWNLOADING,
+                APP_DOWNLOADED,
+                DATA_DOWNLOADING,
+                DATA_DOWNLOADED,
+                COMPUTING,
+                COMPUTED,
+                CONTRIBUTING,
+                CONTRIBUTE_FAILED,
+                CONTRIBUTED,
+                REVEALING,
+                REVEAL_FAILED,
+                REVEALED,
+                RESULT_UPLOAD_REQUESTED,
+                RESULT_UPLOAD_REQUEST_FAILED,
+                RESULT_UPLOADING,
+                RESULT_UPLOAD_FAILED,
+                RESULT_UPLOADED,
+                COMPLETING,
+                COMPLETE_FAILED,
+                COMPLETED,
+                FAILED,
+                ABORTED,
+                RECOVERING,
+                WORKER_LOST
+        );
+
+        runningFailures   .forEach(status -> assertTrue (ReplicateStatus.isRunningFailure(status)));
+        notRunningFailures.forEach(status -> assertFalse(ReplicateStatus.isRunningFailure(status)));
+    }
 }

--- a/src/test/java/com/iexec/common/replicate/ReplicateStatusTests.java
+++ b/src/test/java/com/iexec/common/replicate/ReplicateStatusTests.java
@@ -59,7 +59,7 @@ public class ReplicateStatusTests {
     }
 
     @Test
-    void shouldBeRunningFailures() {
+    void shouldBeFailedBeforeComputed() {
         final List<ReplicateStatus> runningFailures = List.of(
                 START_FAILED,
                 APP_DOWNLOAD_FAILED,
@@ -96,7 +96,7 @@ public class ReplicateStatusTests {
                 WORKER_LOST
         );
 
-        runningFailures   .forEach(status -> assertTrue (ReplicateStatus.isRunningFailure(status)));
-        notRunningFailures.forEach(status -> assertFalse(ReplicateStatus.isRunningFailure(status)));
+        runningFailures   .forEach(status -> assertTrue (ReplicateStatus.isFailedBeforeComputed(status)));
+        notRunningFailures.forEach(status -> assertFalse(ReplicateStatus.isFailedBeforeComputed(status)));
     }
 }


### PR DESCRIPTION
Add a "running failure" Replicate meta-status: it includes all failures that can be encountered before a `COMPUTED` status has been reached.