### PR TITLE
Feature/update publishing plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
             }
             steps {
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'nexus', usernameVariable: 'NEXUS_USER', passwordVariable: 'NEXUS_PASSWORD']]) {
-                    sh './gradlew uploadArchives -PnexusUser=$NEXUS_USER -PnexusPassword=$NEXUS_PASSWORD --no-daemon'
+                    sh './gradlew publish -PnexusUser=$NEXUS_USER -PnexusPassword=$NEXUS_PASSWORD --no-daemon'
                 }
                 archiveArtifacts artifacts: 'build/libs/*.jar'
             }

--- a/build.gradle
+++ b/build.gradle
@@ -20,10 +20,6 @@ repositories {
     }
 }
 
-configurations {
-    deployerJars
-}
-
 dependencies {
     // web3j dependency
     implementation "org.web3j:core:4.7.0"
@@ -67,9 +63,6 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.6.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.6.0'
     testImplementation 'org.assertj:assertj-core:3.18.1'
-
-    // package cloud
-    deployerJars "io.packagecloud.maven.wagon:maven-packagecloud-wagon:0.0.6"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -105,9 +105,8 @@ jar {
 }
 
 shadowJar { //required if we want to embed web3j dependency inside
-    baseName = rootProject.name
+    archiveClassifier.set('all')
     from sourceSets.main.allSource
-    version = version
 }
 build.dependsOn(shadowJar)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java'
+    id 'java-library'
     id 'eclipse'
     id 'maven-publish'
     id 'jacoco'
@@ -20,12 +20,15 @@ repositories {
     }
 }
 
+// java-library plugin defines 'api' configuration
+// 'api' configuration allows to expose dependencies with 'compile' scope in pom
+// 'implementation' configuration allows to expose dependencies with 'runtime' scope in pom
 dependencies {
     // web3j dependency
-    implementation "org.web3j:core:4.7.0"
+    api "org.web3j:core:4.7.0"
     
     // apache commons.lang3
-    implementation "org.apache.commons:commons-lang3:3.9"
+    api "org.apache.commons:commons-lang3:3.9"
 
     // multiaddresses (IPFS)
     implementation 'com.github.multiformats:java-multiaddr:1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -95,11 +95,18 @@ build.dependsOn jacocoTestReport
 jar {
     // include source code in the jar
     from sourceSets.main.allSource
+    // avoid duplicate application.properties import from jar and sources
+    duplicatesStrategy = 'exclude'
 }
 
-shadowJar { //required if we want to embed web3j dependency inside
+// required if we want to embed web3j dependency inside
+shadowJar {
+    // classifier to produce 2 identified jar files
     archiveClassifier.set('all')
+    // include source code in the jar
     from sourceSets.main.allSource
+    // avoid duplicate application.properties import from jar and sources
+    duplicatesStrategy = 'exclude'
 }
 build.dependsOn(shadowJar)
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'eclipse'
-    id 'maven'
+    id 'maven-publish'
     id 'jacoco'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
     id 'org.sonarqube' version '2.7'
@@ -119,13 +119,21 @@ project.ext.getNexusMaven = {
     }
 }
 
-uploadArchives {
-    repositories.mavenDeployer {
-        configuration = configurations.deployerJars
-        repository(url: getNexusMaven()) {
-            authentication(userName: nexusUser, password: nexusPassword)
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+    repositories {
+        maven {
+            credentials {
+                username nexusUser
+                password nexusPassword
+            }
+            url = getNexusMaven
         }
     }
 }
 
-uploadArchives.enabled = canUploadArchives
+publish.enabled = canUploadArchives

--- a/build.gradle
+++ b/build.gradle
@@ -26,22 +26,22 @@ configurations {
 
 dependencies {
     // web3j dependency
-    compile "org.web3j:core:4.7.0"
+    implementation "org.web3j:core:4.7.0"
     
     // apache commons.lang3
-    compile "org.apache.commons:commons-lang3:3.9"
+    implementation "org.apache.commons:commons-lang3:3.9"
 
     // multiaddresses (IPFS)
-    compile 'com.github.multiformats:java-multiaddr:1.3.1'
+    implementation 'com.github.multiformats:java-multiaddr:1.3.1'
 
     //jaxb required with Java 11
-    compile 'javax.xml.bind:jaxb-api:2.3.0'
+    implementation 'javax.xml.bind:jaxb-api:2.3.0'
 
     //args utils
-    compile 'org.apache.maven.shared:maven-shared-utils:3.2.1'
+    implementation 'org.apache.maven.shared:maven-shared-utils:3.2.1'
 
     // zip
-    compile 'net.lingala.zip4j:zip4j:2.3.1'
+    implementation 'net.lingala.zip4j:zip4j:2.3.1'
 
     // google core libs
     implementation "com.google.guava:guava:28.2-jre"


### PR DESCRIPTION
Use 'maven-publish' plugin.
Use `./gradlew clean publishToMavenLocal`, then retrieve dependency in iexec-core or iexec-worker without editing `build.gradle.`

Project moved to `java-library` plugin to write POM with web3j dependencies at `compile` maven scope.
This is done with the new `api` configuration.

It is kind of a dirty fix.
The right way would be to create a platform project and to manage a BOM like it is done in Spring framework.
But this is entirely another beast to handle for the moment.