### PR TITLE
Feature/build javadoc sources jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,11 @@ ext {
     isDev = project.hasProperty('dev')
 }
 
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
+
 test {
     useJUnitPlatform {
         if (isDev) {
@@ -101,13 +106,6 @@ jacocoTestReport {
 }
 tasks.test.finalizedBy    tasks.jacocoTestReport
 tasks.sonarqube.dependsOn tasks.jacocoTestReport
-
-jar {
-    // include source code in the jar
-    from sourceSets.main.allSource
-    // avoid duplicate application.properties import from jar and sources
-    duplicatesStrategy = 'exclude'
-}
 
 // required if we want to embed web3j dependency inside
 shadowJar {

--- a/src/main/java/com/iexec/common/precompute/PreComputeExitCode.java
+++ b/src/main/java/com/iexec/common/precompute/PreComputeExitCode.java
@@ -27,8 +27,8 @@ import java.util.stream.Collectors;
  * To avoid confusion with exit codes of the chroot standard
  * (followed also by docker), we use exit codes between
  * 64 and 113 which is also conform with the C/C++ standard.
- * @see https://tldp.org/LDP/abs/html/exitcodes.html
- * @see https://docs.docker.com/engine/reference/run/#exit-status
+ * @see <a href="https://tldp.org/LDP/abs/html/exitcodes.html">Reserved Exit Codes</a>
+ * @see <a href="https://docs.docker.com/engine/reference/run/#exit-status">Docker run Exit Status</a>
  */
 public enum PreComputeExitCode {
 

--- a/src/main/java/com/iexec/common/security/CipherUtils.java
+++ b/src/main/java/com/iexec/common/security/CipherUtils.java
@@ -149,7 +149,7 @@ public class CipherUtils {
      * @return encrypted data prepended with the IV.
      * @throws GeneralSecurityException
      * 
-     * @see https://stackoverflow.com/a/34004582 for large files
+     * @see <a href="https://stackoverflow.com/a/34004582">AES encryption on file over 1GB</a> for large files
      */
     public static byte[] aesEncrypt(byte[] plainData, byte[] base64Key)
             throws GeneralSecurityException, IOException {
@@ -174,7 +174,7 @@ public class CipherUtils {
      * @return Encrypted data
      * @throws GeneralSecurityException
      * 
-     * @see https://stackoverflow.com/a/34004582 for large files
+     * @see <a href="https://stackoverflow.com/a/34004582">AES encryption on file over 1GB</a> for large files
      */
     public static byte[] aesEncrypt(
             @Nonnull byte[] plainData, 
@@ -207,7 +207,7 @@ public class CipherUtils {
      * @throws IllegalArgumentException if the data's length
      * is less than 16 bytes.
      * 
-     * @see https://stackoverflow.com/a/34004582 for large files
+     * @see <a href="https://stackoverflow.com/a/34004582">AES encryption on file over 1GB</a> for large files
      */
     public static byte[] aesDecrypt(byte[] ivAndEncryptedData, byte[] base64Key)
             throws GeneralSecurityException {

--- a/src/main/java/com/iexec/common/utils/EthAddress.java
+++ b/src/main/java/com/iexec/common/utils/EthAddress.java
@@ -24,9 +24,8 @@ public class EthAddress extends org.web3j.abi.datatypes.Address {
      * 
      * @param address in hex
      * @return true if address is valid, false otherwise
-     * @see https://github.com/ChainSafe/web3.js/blob/
-     * 5d027191c5cb7ffbcd44083528bdab19b4e14744/packages/web3-utils/src/
-     * utils.js#L88
+     * @see <a href="https://github.com/ChainSafe/web3.js/blob/5d027191c5cb7ffbcd44083528bdab19b4e14744/packages/web3-utils/src/utils.js#L88">
+     * web3.js isAddress implementation</a>
      */
     public static boolean validate(String address) {
         // check address is not empty and contains the valid


### PR DESCRIPTION
Use Gradle mechanisms to produce javadoc and sources artifacts.
Remove copy of source in library jar.
When referencing the iexec-common dependency, this allows to navigate through source code like the other mainstream libraries.
Fixed the javadoc errors, hyperlinks need to be wrapper in anchor tags.