### PR TITLE
Feature/provide requester secret refs in deal params

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,10 +21,10 @@ ext {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url "https://jitpack.io"
     }
+    jcenter()
 }
 
 // java-library plugin defines 'api' configuration

--- a/build.gradle
+++ b/build.gradle
@@ -61,9 +61,7 @@ dependencies {
     implementation 'net.jodah:failsafe:2.4.4'
 
     // test
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
-    testImplementation 'org.mockito:mockito-core:3.6.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.6.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.6.0'
     testImplementation 'org.assertj:assertj-core:3.18.1'
 }

--- a/src/main/java/com/iexec/common/chain/ChainDeal.java
+++ b/src/main/java/com/iexec/common/chain/ChainDeal.java
@@ -24,7 +24,8 @@ import org.web3j.tuples.generated.Tuple9;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -72,15 +73,19 @@ public class ChainDeal {
         try {
             DealParams dealParams = new ObjectMapper().readValue(params, DealParams.class);
             if (dealParams.getIexecInputFiles() == null) {
-                dealParams.setIexecInputFiles(new ArrayList<>());
+                dealParams.setIexecInputFiles(List.of());
+            }
+            if (dealParams.getIexecSecrets() == null) {
+                dealParams.setIexecSecrets(Map.of());
             }
             return dealParams;
         } catch (IOException e) {
             //the requester want to execute one task with the whole string
             return DealParams.builder()
                     .iexecArgs(params)
-                    .iexecInputFiles(new ArrayList<>())
+                    .iexecInputFiles(List.of())
                     .iexecDeveloperLoggerEnabled(false)
+                    .iexecSecrets(Map.of())
                     .build();
         }
     }

--- a/src/main/java/com/iexec/common/chain/ChainDeal.java
+++ b/src/main/java/com/iexec/common/chain/ChainDeal.java
@@ -24,8 +24,7 @@ import org.web3j.tuples.generated.Tuple9;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.util.List;
-import java.util.Map;
+import java.util.Collections;
 
 @Data
 @NoArgsConstructor
@@ -73,19 +72,19 @@ public class ChainDeal {
         try {
             DealParams dealParams = new ObjectMapper().readValue(params, DealParams.class);
             if (dealParams.getIexecInputFiles() == null) {
-                dealParams.setIexecInputFiles(List.of());
+                dealParams.setIexecInputFiles(Collections.emptyList());
             }
             if (dealParams.getIexecSecrets() == null) {
-                dealParams.setIexecSecrets(Map.of());
+                dealParams.setIexecSecrets(Collections.emptyMap());
             }
             return dealParams;
         } catch (IOException e) {
             //the requester want to execute one task with the whole string
             return DealParams.builder()
                     .iexecArgs(params)
-                    .iexecInputFiles(List.of())
+                    .iexecInputFiles(Collections.emptyList())
                     .iexecDeveloperLoggerEnabled(false)
-                    .iexecSecrets(Map.of())
+                    .iexecSecrets(Collections.emptyMap())
                     .build();
         }
     }

--- a/src/main/java/com/iexec/common/chain/ChainDeal.java
+++ b/src/main/java/com/iexec/common/chain/ChainDeal.java
@@ -16,15 +16,12 @@
 
 package com.iexec.common.chain;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iexec.common.utils.BytesUtils;
 import lombok.*;
 import org.web3j.tuples.generated.Tuple6;
 import org.web3j.tuples.generated.Tuple9;
 
-import java.io.IOException;
 import java.math.BigInteger;
-import java.util.Collections;
 
 @Data
 @NoArgsConstructor
@@ -68,27 +65,6 @@ public class ChainDeal {
                 !getChainDataset().getChainDatasetId().equals(BytesUtils.EMPTY_ADDRESS);
     }
 
-    public static DealParams stringToDealParams(String params) {
-        try {
-            DealParams dealParams = new ObjectMapper().readValue(params, DealParams.class);
-            if (dealParams.getIexecInputFiles() == null) {
-                dealParams.setIexecInputFiles(Collections.emptyList());
-            }
-            if (dealParams.getIexecSecrets() == null) {
-                dealParams.setIexecSecrets(Collections.emptyMap());
-            }
-            return dealParams;
-        } catch (IOException e) {
-            //the requester want to execute one task with the whole string
-            return DealParams.builder()
-                    .iexecArgs(params)
-                    .iexecInputFiles(Collections.emptyList())
-                    .iexecDeveloperLoggerEnabled(false)
-                    .iexecSecrets(Collections.emptyMap())
-                    .build();
-        }
-    }
-
     public static ChainDeal parts2ChainDeal(String chainDealId, Tuple9<String, String, BigInteger, String, String, BigInteger, String, String, BigInteger> dealPt1, Tuple6<BigInteger, byte[], String, String, String, String> dealPt2, Tuple6<BigInteger, BigInteger, BigInteger, BigInteger, BigInteger, BigInteger> config, ChainApp app, ChainCategory category, ChainDataset dataset) {
         if (dealPt1 == null || dealPt2 == null || config == null || app == null || category == null) {
             return new ChainDeal();
@@ -109,7 +85,7 @@ public class ChainDeal {
                 .requester(dealPt2.component3())
                 .beneficiary(dealPt2.component4())
                 .callback(dealPt2.component5())
-                .params(stringToDealParams(dealPt2.component6()))
+                .params(DealParams.createFromString(dealPt2.component6()))
                 .chainCategory(category)
                 .startTime(config.component2())
                 .botFirst(config.component3())

--- a/src/main/java/com/iexec/common/chain/DealParams.java
+++ b/src/main/java/com/iexec/common/chain/DealParams.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -50,6 +51,10 @@ public class DealParams {
     @JsonProperty("iexec_result_storage_proxy")
     private String iexecResultStorageProxy;
 
+    // Keys are app secrets indices, values are requester secrets indices
+    @JsonProperty("iexec_secrets")
+    private Map<String, String> iexecSecrets;
+
     //Should be set by SDK
     @JsonProperty("iexec_tee_post_compute_image")
     private String iexecTeePostComputeImage;
@@ -57,6 +62,5 @@ public class DealParams {
     //Should be set by SDK
     @JsonProperty("iexec_tee_post_compute_fingerprint")
     private String iexecTeePostComputeFingerprint;
-
 
 }

--- a/src/main/java/com/iexec/common/chain/DealParams.java
+++ b/src/main/java/com/iexec/common/chain/DealParams.java
@@ -17,11 +17,69 @@
 package com.iexec.common.chain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+/**
+ * The DealParams class represents runtime configurations provided for tasks computation.
+ * DealParams allow a requester to provide <b>args</b>, <b>input files</b>, <b>secrets</b>,
+ * <b>result storage configuration</b>... Those configurations are written on the blockchain
+ * when a deal is submitted.
+ * <p>
+ * The data written on the blockchain can be:
+ * <ul>
+ * <li> A valid JSON string representing a map with key -&gt; value pairs.
+ *      The keys are mapped to DealParams fields: iexec_args, iexec_input_files, iexec_secrets, iexec_developer_logger,
+ *      iexec_result_encryption, iexec_result_storage_provider, iexec_result_storage_proxy.
+ * <li> A simple string that will be used for <b>iexec_args</b>
+ * </ul>
+ * <p>
+ * The <b>iexec_secrets</b> key -&gt; value map declares which secrets of the requester
+ * can be accessed by a targeted TEE application.
+ * <ul>
+ * <li>A value should hold the secret name of a secret belonging to the requester.
+ *     This secret must be previously pushed on the SMS.
+ * <li>A key associated to a value indicates how the TEE application can access
+ *     that value.
+ * </ul>
+ * <p>
+ * Example:
+ * <ul>
+ * <li>A requester has a secret value "2000-01-01" pushed on the SMS. The name of
+ *     this secret is "my-birthday".
+ * <li>A requester has a secret value "+33123456789" pushed on the SMS. The name
+ *     of this secret is "my-phone-number".
+ * </ul>
+ * <p>
+ * The application developer creates a TEE application which allows requesters
+ * to :
+ * <ol>
+ * <li>Share their birthday by affecting their secret to position "2"
+ * <li>Share their phone number by affecting their secret to position "5"
+ * </ol>
+ * <p>
+ * In order to share birthday and phone number to the TEE application, the
+ * requester should declare:
+ * <pre>"iexec_secrets" : { "2": "my-birthday" , "5": "my-phone-number" }</pre>
+ * <p>
+ * By doing this, the TEE application code will be able to read following
+ * environment variables:
+ * <pre>
+ * IEXEC_REQUESTER_SECRET_2=2000-01-01
+ * IEXEC_REQUESTER_SECRET_5=+33123456789
+ * </pre>
+ */
+@Slf4j
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -62,5 +120,49 @@ public class DealParams {
     //Should be set by SDK
     @JsonProperty("iexec_tee_post_compute_fingerprint")
     private String iexecTeePostComputeFingerprint;
+
+    /**
+     * Creates an instance from a JSON string representation.
+     * @param paramString data to create a DealParams instance.
+     *                    The value will be parsed if it is a valid JSON string,
+     *                    it will be used as <b>iexecArgs</b> value otherwise.
+     *                    In the second case, every other parameters will have default values.
+     * @return the created instance
+     */
+    public static DealParams createFromString(String paramString) {
+        try {
+            DealParams dealParams = new ObjectMapper().readValue(paramString, DealParams.class);
+            if (dealParams.getIexecInputFiles() == null) {
+                dealParams.setIexecInputFiles(Collections.emptyList());
+            }
+            if (dealParams.getIexecSecrets() == null) {
+                dealParams.setIexecSecrets(Collections.emptyMap());
+            }
+            return dealParams;
+        } catch (IOException e) {
+            //the requester want to execute one task with the whole string
+            return DealParams.builder()
+                    .iexecArgs(paramString)
+                    .iexecInputFiles(Collections.emptyList())
+                    .iexecDeveloperLoggerEnabled(false)
+                    .iexecSecrets(Collections.emptyMap())
+                    .build();
+        }
+    }
+
+    /**
+     * Represents the instance as a JSON string that will be written on chain.
+     * @return the JSON string representing the instance
+     */
+    public String toJsonString() {
+        ObjectMapper mapper = new ObjectMapper();
+        Arrays.asList(NON_NULL, NON_EMPTY, NON_DEFAULT).forEach(mapper::setSerializationInclusion);
+        try {
+            return mapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            log.error("Deal parameters serialization failed.", e);
+            return "";
+        }
+    }
 
 }

--- a/src/main/java/com/iexec/common/sdk/order/payload/RequestOrder.java
+++ b/src/main/java/com/iexec/common/sdk/order/payload/RequestOrder.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iexec.common.chain.DealParams;
 import lombok.*;
+import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
 import static com.iexec.common.sdk.order.OrderUtils.toLowerCase;
 
 @Data
+@Slf4j
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 @NoArgsConstructor
@@ -70,7 +72,7 @@ public class RequestOrder extends Order {
         try {
             return mapper.writeValueAsString(params);
         } catch (JsonProcessingException e) {
-            e.printStackTrace();
+            log.error("Deal parameters serialization failed.", e);
         }
         return "";
     }

--- a/src/main/java/com/iexec/common/sdk/order/payload/RequestOrder.java
+++ b/src/main/java/com/iexec/common/sdk/order/payload/RequestOrder.java
@@ -16,17 +16,13 @@
 
 package com.iexec.common.sdk.order.payload;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iexec.common.chain.DealParams;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Objects;
 
-import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
 import static com.iexec.common.sdk.order.OrderUtils.toLowerCase;
 
 @Data
@@ -66,15 +62,14 @@ public class RequestOrder extends Order {
         this.params = params;
     }
 
+    /**
+     * @deprecated Use {@link DealParams#toJsonString()} instead.
+     * @param params Deal parameters to write on chain
+     * @return JSON string that will be written on chain
+     */
+    @Deprecated
     public static String toStringParams(DealParams params) {
-        ObjectMapper mapper = new ObjectMapper();
-        Arrays.asList(NON_NULL, NON_EMPTY, NON_DEFAULT).forEach(mapper::setSerializationInclusion);
-        try {
-            return mapper.writeValueAsString(params);
-        } catch (JsonProcessingException e) {
-            log.error("Deal parameters serialization failed.", e);
-        }
-        return "";
+        return params.toJsonString();
     }
 
     public void setApp(String app) {

--- a/src/main/java/com/iexec/common/task/TaskDescription.java
+++ b/src/main/java/com/iexec/common/task/TaskDescription.java
@@ -29,6 +29,7 @@ import lombok.NoArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Map;
 
 @Data
 @NoArgsConstructor
@@ -59,6 +60,7 @@ public class TaskDescription {
     private boolean isResultEncryption;
     private String resultStorageProvider;
     private String resultStorageProxy;
+    private Map<String, String> secrets;
     private String teePostComputeImage;
     private String teePostComputeFingerprint;
 
@@ -142,6 +144,11 @@ public class TaskDescription {
                 chainDeal.getParams().getIexecInputFiles() != null) {
             inputFiles = chainDeal.getParams().getIexecInputFiles();
         }
+        Map<String, String> secrets = Map.of();
+        if (chainDeal.getParams() != null &&
+                chainDeal.getParams().getIexecSecrets() != null) {
+            secrets = chainDeal.getParams().getIexecSecrets();
+        }
         return TaskDescription.builder()
                 .chainTaskId(chainTaskId)
                 .requester(chainDeal
@@ -165,12 +172,13 @@ public class TaskDescription {
                         .isTeeTag(chainDeal.getTag()))
                 .developerLoggerEnabled(chainDeal.getParams()
                         .isIexecDeveloperLoggerEnabled())
+                .isResultEncryption(chainDeal.getParams()
+                        .isIexecResultEncryption())
                 .resultStorageProvider(chainDeal.getParams()
                         .getIexecResultStorageProvider())
                 .resultStorageProxy(chainDeal.getParams()
                         .getIexecResultStorageProxy())
-                .isResultEncryption(chainDeal.getParams()
-                        .isIexecResultEncryption())
+                .secrets(secrets)
                 .teePostComputeImage(chainDeal.getParams()
                         .getIexecTeePostComputeImage())
                 .teePostComputeFingerprint(chainDeal.getParams()

--- a/src/main/java/com/iexec/common/task/TaskDescription.java
+++ b/src/main/java/com/iexec/common/task/TaskDescription.java
@@ -139,16 +139,6 @@ public class TaskDescription {
             datasetName = chainDeal.getChainDataset().getName();
             datasetChecksum = chainDeal.getChainDataset().getChecksum();
         }
-        List<String> inputFiles = List.of();
-        if (chainDeal.getParams() != null &&
-                chainDeal.getParams().getIexecInputFiles() != null) {
-            inputFiles = chainDeal.getParams().getIexecInputFiles();
-        }
-        Map<String, String> secrets = Map.of();
-        if (chainDeal.getParams() != null &&
-                chainDeal.getParams().getIexecSecrets() != null) {
-            secrets = chainDeal.getParams().getIexecSecrets();
-        }
         return TaskDescription.builder()
                 .chainTaskId(chainTaskId)
                 .requester(chainDeal
@@ -165,7 +155,8 @@ public class TaskDescription {
                         .getEnclaveConfiguration())
                 .cmd(chainDeal.getParams()
                         .getIexecArgs())
-                .inputFiles(inputFiles)
+                .inputFiles(chainDeal.getParams()
+                        .getIexecInputFiles())
                 .maxExecutionTime(chainDeal.getChainCategory()
                         .getMaxExecutionTime())
                 .isTeeTask(TeeUtils
@@ -178,7 +169,8 @@ public class TaskDescription {
                         .getIexecResultStorageProvider())
                 .resultStorageProxy(chainDeal.getParams()
                         .getIexecResultStorageProxy())
-                .secrets(secrets)
+                .secrets(chainDeal.getParams()
+                        .getIexecSecrets())
                 .teePostComputeImage(chainDeal.getParams()
                         .getIexecTeePostComputeImage())
                 .teePostComputeFingerprint(chainDeal.getParams()

--- a/src/main/java/com/iexec/common/utils/IexecEnvUtils.java
+++ b/src/main/java/com/iexec/common/utils/IexecEnvUtils.java
@@ -50,6 +50,9 @@ public class IexecEnvUtils {
     public static final String IEXEC_INPUT_FILES_FOLDER = "IEXEC_INPUT_FILES_FOLDER";
     public static final String IEXEC_INPUT_FILE_NAME_PREFIX = "IEXEC_INPUT_FILE_NAME_";
     public static final String IEXEC_INPUT_FILE_URL_PREFIX = "IEXEC_INPUT_FILE_URL_";
+    // secrets
+    public static final String IEXEC_APP_DEVELOPER_SECRET_PREFIX = "IEXEC_APP_DEVELOPER_SECRET_";
+    public static final String IEXEC_REQUESTER_SECRET_PREFIX = "IEXEC_REQUESTER_SECRET_";
 
     private IexecEnvUtils() {
         throw new UnsupportedOperationException();
@@ -88,7 +91,7 @@ public class IexecEnvUtils {
      * @return
      */
     public static Map<String, String> getComputeStageEnvMap(TaskDescription taskDescription) {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put(IEXEC_TASK_ID, taskDescription.getChainTaskId());
         map.put(IEXEC_IN, IexecFileHelper.SLASH_IEXEC_IN);
         map.put(IEXEC_OUT, IexecFileHelper.SLASH_IEXEC_OUT);

--- a/src/test/java/com/iexec/common/chain/ChainDealTest.java
+++ b/src/test/java/com/iexec/common/chain/ChainDealTest.java
@@ -17,7 +17,6 @@
 package com.iexec.common.chain;
 
 import com.iexec.common.utils.BytesUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.web3j.tuples.generated.Tuple6;
 import org.web3j.tuples.generated.Tuple9;
@@ -66,29 +65,7 @@ class ChainDealTest {
     @Test
     void testEmptyConstructor() {
         ChainDeal deal = new ChainDeal();
-        Assertions.assertNull(deal.getBeneficiary());
-        Assertions.assertNull(deal.getBotFirst());
-        Assertions.assertNull(deal.getBotSize());
-        Assertions.assertNull(deal.getCallback());
-        Assertions.assertNull(deal.getChainApp());
-        Assertions.assertNull(deal.getChainCategory());
-        Assertions.assertNull(deal.getChainDataset());
-        Assertions.assertNull(deal.getChainDealId());
-        Assertions.assertNull(deal.getDappOwner());
-        Assertions.assertNull(deal.getDappPrice());
-        Assertions.assertNull(deal.getDataOwner());
-        Assertions.assertNull(deal.getDataPointer());
-        Assertions.assertNull(deal.getDataPrice());
-        Assertions.assertNull(deal.getParams());
-        Assertions.assertNull(deal.getPoolOwner());
-        Assertions.assertNull(deal.getPoolPointer());
-        Assertions.assertNull(deal.getPoolPrice());
-        Assertions.assertNull(deal.getRequester());
-        Assertions.assertNull(deal.getSchedulerRewardRatio());
-        Assertions.assertNull(deal.getStartTime());
-        Assertions.assertNull(deal.getTag());
-        Assertions.assertNull(deal.getTrust());
-        Assertions.assertNull(deal.getWorkerStake());
+        org.assertj.core.api.Assertions.assertThat(deal).hasAllNullFieldsOrProperties();
     }
 
     @Test
@@ -96,7 +73,7 @@ class ChainDealTest {
         DealParams params = stringToDealParams(ARGS);
         assertEquals(ARGS, params.getIexecArgs());
         assertEquals(0, params.getIexecInputFiles().size());
-        assertEquals(0,params.getIexecSecrets().size());
+        assertEquals(0, params.getIexecSecrets().size());
     }
 
     @Test

--- a/src/test/java/com/iexec/common/chain/ChainDealTest.java
+++ b/src/test/java/com/iexec/common/chain/ChainDealTest.java
@@ -17,6 +17,7 @@
 package com.iexec.common.chain;
 
 import com.iexec.common.utils.BytesUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.web3j.tuples.generated.Tuple6;
 import org.web3j.tuples.generated.Tuple9;
@@ -63,10 +64,39 @@ class ChainDealTest {
     private static final String FILE3 = "http://test.com/image3.png";
 
     @Test
+    void testEmptyConstructor() {
+        ChainDeal deal = new ChainDeal();
+        Assertions.assertNull(deal.getBeneficiary());
+        Assertions.assertNull(deal.getBotFirst());
+        Assertions.assertNull(deal.getBotSize());
+        Assertions.assertNull(deal.getCallback());
+        Assertions.assertNull(deal.getChainApp());
+        Assertions.assertNull(deal.getChainCategory());
+        Assertions.assertNull(deal.getChainDataset());
+        Assertions.assertNull(deal.getChainDealId());
+        Assertions.assertNull(deal.getDappOwner());
+        Assertions.assertNull(deal.getDappPrice());
+        Assertions.assertNull(deal.getDataOwner());
+        Assertions.assertNull(deal.getDataPointer());
+        Assertions.assertNull(deal.getDataPrice());
+        Assertions.assertNull(deal.getParams());
+        Assertions.assertNull(deal.getPoolOwner());
+        Assertions.assertNull(deal.getPoolPointer());
+        Assertions.assertNull(deal.getPoolPrice());
+        Assertions.assertNull(deal.getRequester());
+        Assertions.assertNull(deal.getSchedulerRewardRatio());
+        Assertions.assertNull(deal.getStartTime());
+        Assertions.assertNull(deal.getTag());
+        Assertions.assertNull(deal.getTrust());
+        Assertions.assertNull(deal.getWorkerStake());
+    }
+
+    @Test
     void shouldReadArgsWithoutJson() {
         DealParams params = stringToDealParams(ARGS);
         assertEquals(ARGS, params.getIexecArgs());
         assertEquals(0, params.getIexecInputFiles().size());
+        assertEquals(0,params.getIexecSecrets().size());
     }
 
     @Test
@@ -74,14 +104,16 @@ class ChainDealTest {
         DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"}");
         assertEquals(ARGS, params.getIexecArgs());
         assertEquals(0, params.getIexecInputFiles().size());
+        assertEquals(0, params.getIexecSecrets().size());
     }
 
     @Test
-    void shouldReadArgsInJsonAndEmptyInputFiles() {
+    void shouldReadArgsInJsonAndEmptyInputFilesAndEmptySecrets() {
         DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
-                "\"iexec_input_files\":[]}");
+                "\"iexec_input_files\":[],\"iexec_secrets\":{}}");
         assertEquals(ARGS, params.getIexecArgs());
         assertEquals(0, params.getIexecInputFiles().size());
+        assertEquals(0, params.getIexecSecrets().size());
     }
 
 
@@ -103,6 +135,32 @@ class ChainDealTest {
         assertEquals(FILE1, params.getIexecInputFiles().get(0));
         assertEquals(FILE2, params.getIexecInputFiles().get(1));
         assertEquals(FILE3, params.getIexecInputFiles().get(2));
+    }
+
+    @Test
+    void shouldReadArgsAndMultipleSecrets() {
+        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
+                "\"iexec_secrets\":{\"1\":\"secretK\",\"2\":\"secretX\"}}");
+        assertEquals(ARGS, params.getIexecArgs());
+        assertEquals(0, params.getIexecInputFiles().size());
+        assertEquals(2, params.getIexecSecrets().size());
+        assertEquals("secretK", params.getIexecSecrets().get("1"));
+        assertEquals("secretX", params.getIexecSecrets().get("2"));
+    }
+
+    @Test
+    void shouldReadArgsAndMultipleFilesAndMultipleSecrets() {
+        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
+                "\"iexec_input_files\":[\"" + FILE3 + "\",\"" + FILE2 + "\",\"" + FILE1 + "\"]," +
+                "\"iexec_secrets\":{\"1\":\"secretX\",\"2\":\"secretK\"}}");
+        assertEquals(ARGS, params.getIexecArgs());
+        assertEquals(3, params.getIexecInputFiles().size());
+        assertEquals(FILE3, params.getIexecInputFiles().get(0));
+        assertEquals(FILE2, params.getIexecInputFiles().get(1));
+        assertEquals(FILE1, params.getIexecInputFiles().get(2));
+        assertEquals(2, params.getIexecSecrets().size());
+        assertEquals("secretX", params.getIexecSecrets().get("1"));
+        assertEquals("secretK", params.getIexecSecrets().get("2"));
     }
 
     @Test

--- a/src/test/java/com/iexec/common/chain/ChainDealTest.java
+++ b/src/test/java/com/iexec/common/chain/ChainDealTest.java
@@ -23,7 +23,6 @@ import org.web3j.tuples.generated.Tuple9;
 
 import java.math.BigInteger;
 
-import static com.iexec.common.chain.ChainDeal.stringToDealParams;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -57,10 +56,6 @@ class ChainDealTest {
                     BigInteger.valueOf(5),
                     BigInteger.valueOf(6));
     public static final String CHAIN_DEAL_ID = "chainDeal";
-    private static final String ARGS = "argument for the worker";
-    private static final String FILE1 = "http://test.com/image1.png";
-    private static final String FILE2 = "http://test.com/image2.png";
-    private static final String FILE3 = "http://test.com/image3.png";
 
     @Test
     void testEmptyConstructor() {
@@ -68,86 +63,6 @@ class ChainDealTest {
         org.assertj.core.api.Assertions.assertThat(deal).hasAllNullFieldsOrProperties();
     }
 
-    @Test
-    void shouldReadArgsWithoutJson() {
-        DealParams params = stringToDealParams(ARGS);
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(0, params.getIexecInputFiles().size());
-        assertEquals(0, params.getIexecSecrets().size());
-    }
-
-    @Test
-    void shouldReadArgsInJson() {
-        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"}");
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(0, params.getIexecInputFiles().size());
-        assertEquals(0, params.getIexecSecrets().size());
-    }
-
-    @Test
-    void shouldReadArgsInJsonAndEmptyInputFilesAndEmptySecrets() {
-        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
-                "\"iexec_input_files\":[],\"iexec_secrets\":{}}");
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(0, params.getIexecInputFiles().size());
-        assertEquals(0, params.getIexecSecrets().size());
-    }
-
-
-    @Test
-    void shouldReadArgsAndOneInputFile() {
-        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
-                "\"iexec_input_files\":[\"" + FILE1 + "\"]}");
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(1, params.getIexecInputFiles().size());
-        assertEquals(FILE1, params.getIexecInputFiles().get(0));
-    }
-
-    @Test
-    void shouldReadArgsAndMultipleFiles() {
-        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
-                "\"iexec_input_files\":[\"" + FILE1 + "\",\"" + FILE2 + "\",\"" + FILE3 + "\"]}");
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(3, params.getIexecInputFiles().size());
-        assertEquals(FILE1, params.getIexecInputFiles().get(0));
-        assertEquals(FILE2, params.getIexecInputFiles().get(1));
-        assertEquals(FILE3, params.getIexecInputFiles().get(2));
-    }
-
-    @Test
-    void shouldReadArgsAndMultipleSecrets() {
-        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
-                "\"iexec_secrets\":{\"1\":\"secretK\",\"2\":\"secretX\"}}");
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(0, params.getIexecInputFiles().size());
-        assertEquals(2, params.getIexecSecrets().size());
-        assertEquals("secretK", params.getIexecSecrets().get("1"));
-        assertEquals("secretX", params.getIexecSecrets().get("2"));
-    }
-
-    @Test
-    void shouldReadArgsAndMultipleFilesAndMultipleSecrets() {
-        DealParams params = stringToDealParams("{\"iexec_args\":\"" + ARGS + "\"," +
-                "\"iexec_input_files\":[\"" + FILE3 + "\",\"" + FILE2 + "\",\"" + FILE1 + "\"]," +
-                "\"iexec_secrets\":{\"1\":\"secretX\",\"2\":\"secretK\"}}");
-        assertEquals(ARGS, params.getIexecArgs());
-        assertEquals(3, params.getIexecInputFiles().size());
-        assertEquals(FILE3, params.getIexecInputFiles().get(0));
-        assertEquals(FILE2, params.getIexecInputFiles().get(1));
-        assertEquals(FILE1, params.getIexecInputFiles().get(2));
-        assertEquals(2, params.getIexecSecrets().size());
-        assertEquals("secretX", params.getIexecSecrets().get("1"));
-        assertEquals("secretK", params.getIexecSecrets().get("2"));
-    }
-
-    @Test
-    void shouldReadNotCorrectJsonFile() {
-        String wrongJson = "{\"wrong_field1\":\"wrong arg value\"," +
-                "\"iexec_input_files\":[\"" + FILE1 + "\"]}";
-        DealParams params = stringToDealParams(wrongJson);
-        assertEquals(wrongJson, params.getIexecArgs());
-        assertEquals(0, params.getIexecInputFiles().size());
-    }
 
     @Test
     void shouldConvertToChainDeal() {
@@ -176,7 +91,7 @@ class ChainDealTest {
                         .requester(DEAL_PT_2.component3())
                         .beneficiary(DEAL_PT_2.component4())
                         .callback(DEAL_PT_2.component5())
-                        .params(stringToDealParams(DEAL_PT_2.component6()))
+                        .params(DealParams.createFromString(DEAL_PT_2.component6()))
                         .chainCategory(category)
                         .startTime(config.component2())
                         .botFirst(config.component3())

--- a/src/test/java/com/iexec/common/chain/DealParamsTest.java
+++ b/src/test/java/com/iexec/common/chain/DealParamsTest.java
@@ -1,0 +1,189 @@
+package com.iexec.common.chain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DealParamsTest {
+
+    private static final String ARGS = "argument for the worker";
+    private static final String FILE1 = "http://test.com/image1.png";
+    private static final String FILE2 = "http://test.com/image2.png";
+    private static final String FILE3 = "http://test.com/image3.png";
+
+    @Test
+    void shouldReadArgsWithoutJson() {
+        DealParams params = DealParams.createFromString(ARGS);
+        assertEquals(ARGS, params.getIexecArgs());
+        assertThat(params.getIexecInputFiles()).isNotNull();
+        assertThat(params.getIexecInputFiles()).isEmpty();
+        assertThat(params.getIexecSecrets()).isNotNull();
+        assertThat(params.getIexecSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldReadArgsInJson() {
+        DealParams params = DealParams.createFromString("{\"iexec_args\":\"" + ARGS + "\"}");
+        assertThat(params.getIexecArgs()).isEqualTo(ARGS);
+        assertThat(params.getIexecInputFiles()).isNotNull();
+        assertThat(params.getIexecInputFiles()).isEmpty();
+        assertThat(params.getIexecSecrets()).isNotNull();
+        assertThat(params.getIexecSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldReadArgsInJsonAndEmptyInputFilesAndEmptySecrets() {
+        DealParams params = DealParams.createFromString("{\"iexec_args\":\"" + ARGS + "\"," +
+                "\"iexec_input_files\":[],\"iexec_secrets\":{}}");
+        assertThat(params.getIexecArgs()).isEqualTo(ARGS);
+        assertThat(params.getIexecInputFiles()).isNotNull();
+        assertThat(params.getIexecInputFiles()).isEmpty();
+        assertThat(params.getIexecSecrets()).isNotNull();
+        assertThat(params.getIexecSecrets()).isEmpty();
+    }
+
+    @Test
+    void shouldReadNotCorrectJsonFile() {
+        String wrongJson = "{\"wrong_field1\":\"wrong arg value\"," +
+                "\"iexec_input_files\":[\"http://file1\"]}";
+        DealParams params = DealParams.createFromString(wrongJson);
+        assertThat(params.getIexecArgs()).isEqualTo(wrongJson);
+        assertThat(params.getIexecInputFiles()).isNotNull();
+        assertThat(params.getIexecInputFiles()).isEmpty();
+    }
+
+    @Test
+    void testSerializationWithBuilderDefaultValues() {
+        DealParams params = DealParams.builder().build();
+        DealParams newParams =  DealParams.createFromString(params.toJsonString());
+        assertThat(newParams)
+                .usingRecursiveComparison()
+                .ignoringFields("iexecInputFiles", "iexecSecrets")
+                .isEqualTo(params);
+        assertThat(params.getIexecInputFiles()).isNull();
+        assertThat(newParams.getIexecInputFiles()).isEqualTo(Collections.emptyList());
+        assertThat(params.getIexecSecrets()).isNull();
+        assertThat(newParams.getIexecSecrets()).isEqualTo(Collections.emptyMap());
+    }
+
+    @Test
+    void testSerializationWithBooleanAsFalse() {
+        DealParams params = DealParams.builder()
+                .iexecDeveloperLoggerEnabled(false)
+                .iexecResultEncryption(false)
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(newParams)
+                .usingRecursiveComparison()
+                .ignoringFields("iexecInputFiles", "iexecSecrets")
+                .isEqualTo(params);
+        assertThat(params.getIexecInputFiles()).isNull();
+        assertThat(newParams.getIexecInputFiles()).isEqualTo(Collections.emptyList());
+        assertThat(params.getIexecSecrets()).isNull();
+        assertThat(newParams.getIexecSecrets()).isEqualTo(Collections.emptyMap());
+    }
+
+    @Test
+    void testSerializationWithBooleanAsTrue() {
+        DealParams params = DealParams.builder()
+                .iexecDeveloperLoggerEnabled(true)
+                .iexecResultEncryption(true)
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(newParams)
+                .usingRecursiveComparison()
+                .ignoringFields("iexecInputFiles", "iexecSecrets")
+                .isEqualTo(params);
+        assertThat(params.getIexecInputFiles()).isNull();
+        assertThat(newParams.getIexecInputFiles()).isEqualTo(Collections.emptyList());
+        assertThat(params.getIexecSecrets()).isNull();
+        assertThat(newParams.getIexecSecrets()).isEqualTo(Collections.emptyMap());
+    }
+
+    @Test
+    void testSerializationForInputFiles() {
+        DealParams params = DealParams.builder()
+                .iexecInputFiles(List.of(FILE1, FILE2))
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(params)
+                .usingRecursiveComparison()
+                .ignoringFields("iexecSecrets")
+                .isEqualTo(newParams);
+        assertThat(params.getIexecSecrets()).isNull();
+        assertThat(newParams.getIexecSecrets()).isEmpty();
+    }
+
+    @Test
+    void testSerializationForSecrets(){
+        DealParams params = DealParams.builder()
+                .iexecSecrets(Map.of("0", "secretA", "3", "secretX"))
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(params)
+                .usingRecursiveComparison()
+                .ignoringFields("iexecInputFiles")
+                .isEqualTo(newParams);
+        assertThat(params.getIexecInputFiles()).isNull();
+        assertThat(newParams.getIexecInputFiles()).isEmpty();
+    }
+
+    @Test
+    void testSerializationWithEmptyArgs() {
+        DealParams params = DealParams.builder()
+                .iexecArgs("")
+                .iexecInputFiles(Collections.emptyList())
+                .iexecSecrets(Collections.emptyMap())
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(params)
+                .usingRecursiveComparison()
+                .ignoringFields("iexecArgs")
+                .isEqualTo(newParams);
+        assertThat(params.getIexecArgs()).isNotNull();
+        assertThat(params.getIexecArgs()).isBlank();
+        assertThat(newParams.getIexecArgs()).isNull();
+        assertThat(params.getIexecInputFiles()).isEmpty();
+        assertThat(newParams.getIexecInputFiles()).isEmpty();
+        assertThat(params.getIexecSecrets()).isEmpty();
+        assertThat(newParams.getIexecSecrets()).isEmpty();
+    }
+
+    @Test
+    void testSerializationWithArgsAndMultipleFilesAndMultipleSecrets() {
+        DealParams params = DealParams.builder()
+                .iexecArgs(ARGS)
+                .iexecInputFiles(List.of(FILE2, FILE3))
+                .iexecSecrets(Map.of("2", "secretK", "1", "secretD"))
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(params).isEqualTo(newParams);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {DealParams.DROPBOX_RESULT_STORAGE_PROVIDER, DealParams.IPFS_RESULT_STORAGE_PROVIDER})
+    void testSerializationWithAllParams(String storageProvider) {
+        DealParams params = DealParams.builder()
+                .iexecArgs(ARGS)
+                .iexecInputFiles(List.of(FILE3, FILE2, FILE1))
+                .iexecSecrets(Map.of("1", "secretC", "2", "secretB", "3", "secretA"))
+                .iexecDeveloperLoggerEnabled(true)
+                .iexecResultEncryption(true)
+                .iexecResultStorageProvider(storageProvider)
+                .iexecResultStorageProxy("http://result-proxy.local:13200")
+                .build();
+        DealParams newParams = DealParams.createFromString(params.toJsonString());
+        assertThat(newParams).isEqualTo(params);
+        assertThat(newParams.getIexecArgs()).isNotBlank();
+        assertThat(newParams.getIexecInputFiles()).isNotEmpty();
+        assertThat(newParams.getIexecSecrets()).isNotEmpty();
+    }
+
+}

--- a/src/test/java/com/iexec/common/sdk/order/payload/RequestOrderTest.java
+++ b/src/test/java/com/iexec/common/sdk/order/payload/RequestOrderTest.java
@@ -3,11 +3,17 @@ package com.iexec.common.sdk.order.payload;
 import com.iexec.common.chain.DealParams;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 class RequestOrderTest {
+
+    private static final String INPUT_FILE1 = "http://file1";
+    private static final String INPUT_FILE2 = "http://file2";
 
     @Test
     void shouldSerializeEmptyMapWhenNoParameters() {
@@ -25,16 +31,25 @@ class RequestOrderTest {
     }
 
     @Test
-    void shouldSerializeParametersWithEncryptedResult() {
-        for (String storageProxy : List.of(DealParams.DROPBOX_RESULT_STORAGE_PROVIDER, DealParams.IPFS_RESULT_STORAGE_PROVIDER)) {
-            String expectedData = "{\"iexec_result_encryption\":true";
-            expectedData += ",\"iexec_result_storage_proxy\":\"" + storageProxy + "\"}";
-            DealParams params = DealParams.builder()
-                    .iexecResultEncryption(true)
-                    .iexecResultStorageProxy(storageProxy)
-                    .build();
-            Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
-        }
+    void shouldSerializeWhenBooleanParametersAreTrue() {
+        String expectedData = "{\"iexec_developer_logger\":true,\"iexec_result_encryption\":true}";
+        DealParams params = DealParams.builder()
+                .iexecDeveloperLoggerEnabled(true)
+                .iexecResultEncryption(true)
+                .build();
+        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {DealParams.DROPBOX_RESULT_STORAGE_PROVIDER, DealParams.IPFS_RESULT_STORAGE_PROVIDER})
+    void shouldSerializeParametersWithEncryptedResult(String storageProvider) {
+        String expectedData = "{\"iexec_result_encryption\":true";
+        expectedData += ",\"iexec_result_storage_provider\":\"" + storageProvider + "\"}";
+        DealParams params = DealParams.builder()
+                .iexecResultEncryption(true)
+                .iexecResultStorageProvider(storageProvider)
+                .build();
+        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
     }
 
     @Test
@@ -48,18 +63,47 @@ class RequestOrderTest {
 
     @Test
     void shouldSerializeInputFiles() {
-        String expectedData = "{\"iexec_input_files\":[\"file1\",\"file2\"]}";
+        String expectedData = "{\"iexec_input_files\":[\"" + INPUT_FILE1 + "\",\"" + INPUT_FILE2 + "\"]}";
         DealParams params = DealParams.builder()
-                .iexecInputFiles(List.of("file1", "file2"))
+                .iexecInputFiles(List.of(INPUT_FILE1, INPUT_FILE2))
                 .build();
         Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
     }
 
     @Test
     void shouldSerializeSecrets() {
-        String expectedData = "{\"iexec_secrets\":{\"0\":\"0\"}}";
+        Map<String, String> secrets = Map.of("0", "secretA", "2", "secretD");
+        String serializedSecrets = secrets.entrySet().stream()
+                .map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
+                .collect(Collectors.joining(","));
+        String expectedData = "{\"iexec_secrets\":{" + serializedSecrets + "}}";
         DealParams params = DealParams.builder()
-                .iexecSecrets(Map.of("0", "0"))
+                .iexecSecrets(Map.of("0", "secretA", "2", "secretD"))
+                .build();
+        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
+    }
+
+    @Test
+    void shouldSerializeAllParams() {
+        Map<String, String> secrets = Map.of("1", "secretA", "0", "secretZ");
+        String serializedSecrets = secrets.entrySet().stream()
+                .map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
+                .collect(Collectors.joining(","));
+        String expectedData = "{";
+        expectedData += "\"iexec_args\":\"arg1 arg2 arg3\",";
+        expectedData += "\"iexec_input_files\":[\"" + INPUT_FILE2 + "\",\"" + INPUT_FILE1 + "\"],";
+        expectedData += "\"iexec_developer_logger\":true,";
+        expectedData += "\"iexec_result_encryption\":true,";
+        expectedData += "\"iexec_result_storage_provider\":\"" + DealParams.IPFS_RESULT_STORAGE_PROVIDER + "\",";
+        expectedData += "\"iexec_secrets\":{" + serializedSecrets + "}";
+        expectedData += "}";
+        DealParams params = DealParams.builder()
+                .iexecArgs("arg1 arg2 arg3")
+                .iexecInputFiles(List.of(INPUT_FILE2, INPUT_FILE1))
+                .iexecSecrets(secrets)
+                .iexecDeveloperLoggerEnabled(true)
+                .iexecResultEncryption(true)
+                .iexecResultStorageProvider(DealParams.IPFS_RESULT_STORAGE_PROVIDER)
                 .build();
         Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
     }

--- a/src/test/java/com/iexec/common/sdk/order/payload/RequestOrderTest.java
+++ b/src/test/java/com/iexec/common/sdk/order/payload/RequestOrderTest.java
@@ -3,17 +3,8 @@ package com.iexec.common.sdk.order.payload;
 import com.iexec.common.chain.DealParams;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 class RequestOrderTest {
-
-    private static final String INPUT_FILE1 = "http://file1";
-    private static final String INPUT_FILE2 = "http://file2";
 
     @Test
     void shouldSerializeEmptyMapWhenNoParameters() {
@@ -28,84 +19,6 @@ class RequestOrderTest {
                 .iexecDeveloperLoggerEnabled(false)
                 .build();
         Assertions.assertEquals("{}", RequestOrder.toStringParams(params));
-    }
-
-    @Test
-    void shouldSerializeWhenBooleanParametersAreTrue() {
-        String expectedData = "{\"iexec_developer_logger\":true,\"iexec_result_encryption\":true}";
-        DealParams params = DealParams.builder()
-                .iexecDeveloperLoggerEnabled(true)
-                .iexecResultEncryption(true)
-                .build();
-        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {DealParams.DROPBOX_RESULT_STORAGE_PROVIDER, DealParams.IPFS_RESULT_STORAGE_PROVIDER})
-    void shouldSerializeParametersWithEncryptedResult(String storageProvider) {
-        String expectedData = "{\"iexec_result_encryption\":true";
-        expectedData += ",\"iexec_result_storage_provider\":\"" + storageProvider + "\"}";
-        DealParams params = DealParams.builder()
-                .iexecResultEncryption(true)
-                .iexecResultStorageProvider(storageProvider)
-                .build();
-        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
-    }
-
-    @Test
-    void shouldSerializeArgs() {
-        String expectedData = "{\"iexec_args\":\"arg1 arg2 arg3\"}";
-        DealParams params = DealParams.builder()
-                .iexecArgs("arg1 arg2 arg3")
-                .build();
-        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
-    }
-
-    @Test
-    void shouldSerializeInputFiles() {
-        String expectedData = "{\"iexec_input_files\":[\"" + INPUT_FILE1 + "\",\"" + INPUT_FILE2 + "\"]}";
-        DealParams params = DealParams.builder()
-                .iexecInputFiles(List.of(INPUT_FILE1, INPUT_FILE2))
-                .build();
-        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
-    }
-
-    @Test
-    void shouldSerializeSecrets() {
-        Map<String, String> secrets = Map.of("0", "secretA", "2", "secretD");
-        String serializedSecrets = secrets.entrySet().stream()
-                .map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
-                .collect(Collectors.joining(","));
-        String expectedData = "{\"iexec_secrets\":{" + serializedSecrets + "}}";
-        DealParams params = DealParams.builder()
-                .iexecSecrets(Map.of("0", "secretA", "2", "secretD"))
-                .build();
-        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
-    }
-
-    @Test
-    void shouldSerializeAllParams() {
-        Map<String, String> secrets = Map.of("1", "secretA", "0", "secretZ");
-        String serializedSecrets = secrets.entrySet().stream()
-                .map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
-                .collect(Collectors.joining(","));
-        String expectedData = "{";
-        expectedData += "\"iexec_args\":\"arg1 arg2 arg3\",";
-        expectedData += "\"iexec_input_files\":[\"" + INPUT_FILE2 + "\",\"" + INPUT_FILE1 + "\"],";
-        expectedData += "\"iexec_developer_logger\":true,";
-        expectedData += "\"iexec_result_encryption\":true,";
-        expectedData += "\"iexec_result_storage_provider\":\"" + DealParams.IPFS_RESULT_STORAGE_PROVIDER + "\",";
-        expectedData += "\"iexec_secrets\":{" + serializedSecrets + "}";
-        expectedData += "}";
-        DealParams params = DealParams.builder()
-                .iexecArgs("arg1 arg2 arg3")
-                .iexecInputFiles(List.of(INPUT_FILE2, INPUT_FILE1))
-                .iexecSecrets(secrets)
-                .iexecDeveloperLoggerEnabled(true)
-                .iexecResultEncryption(true)
-                .iexecResultStorageProvider(DealParams.IPFS_RESULT_STORAGE_PROVIDER)
-                .build();
-        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
     }
 
 }

--- a/src/test/java/com/iexec/common/sdk/order/payload/RequestOrderTest.java
+++ b/src/test/java/com/iexec/common/sdk/order/payload/RequestOrderTest.java
@@ -1,0 +1,67 @@
+package com.iexec.common.sdk.order.payload;
+
+import com.iexec.common.chain.DealParams;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+class RequestOrderTest {
+
+    @Test
+    void shouldSerializeEmptyMapWhenNoParameters() {
+        DealParams params = DealParams.builder().build();
+        Assertions.assertEquals("{}", RequestOrder.toStringParams(params));
+    }
+
+    @Test
+    void shouldSerializeEmptyMapWhenBooleanParametersAreFalse() {
+        DealParams params = DealParams.builder()
+                .iexecResultEncryption(false)
+                .iexecDeveloperLoggerEnabled(false)
+                .build();
+        Assertions.assertEquals("{}", RequestOrder.toStringParams(params));
+    }
+
+    @Test
+    void shouldSerializeParametersWithEncryptedResult() {
+        for (String storageProxy : List.of(DealParams.DROPBOX_RESULT_STORAGE_PROVIDER, DealParams.IPFS_RESULT_STORAGE_PROVIDER)) {
+            String expectedData = "{\"iexec_result_encryption\":true";
+            expectedData += ",\"iexec_result_storage_proxy\":\"" + storageProxy + "\"}";
+            DealParams params = DealParams.builder()
+                    .iexecResultEncryption(true)
+                    .iexecResultStorageProxy(storageProxy)
+                    .build();
+            Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
+        }
+    }
+
+    @Test
+    void shouldSerializeArgs() {
+        String expectedData = "{\"iexec_args\":\"arg1 arg2 arg3\"}";
+        DealParams params = DealParams.builder()
+                .iexecArgs("arg1 arg2 arg3")
+                .build();
+        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
+    }
+
+    @Test
+    void shouldSerializeInputFiles() {
+        String expectedData = "{\"iexec_input_files\":[\"file1\",\"file2\"]}";
+        DealParams params = DealParams.builder()
+                .iexecInputFiles(List.of("file1", "file2"))
+                .build();
+        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
+    }
+
+    @Test
+    void shouldSerializeSecrets() {
+        String expectedData = "{\"iexec_secrets\":{\"0\":\"0\"}}";
+        DealParams params = DealParams.builder()
+                .iexecSecrets(Map.of("0", "0"))
+                .build();
+        Assertions.assertEquals(expectedData, RequestOrder.toStringParams(params));
+    }
+
+}

--- a/src/test/java/com/iexec/common/task/TaskDescriptionTest.java
+++ b/src/test/java/com/iexec/common/task/TaskDescriptionTest.java
@@ -140,7 +140,12 @@ class TaskDescriptionTest {
                 task.getTeePostComputeImage());
         Assertions.assertEquals(TEE_POST_COMPUTE_FINGERPRINT,
                 task.getTeePostComputeFingerprint());
-        Assertions.assertEquals(true, task.containsDataset());
+        Assertions.assertTrue(task.containsDataset());
+    }
+
+    @Test
+    void toTaskDescriptionWithNullDeal() {
+        Assertions.assertNull(TaskDescription.toTaskDescription("0x15", 5, null));
     }
 
     @Test


### PR DESCRIPTION
Ground work needed to handle requester secret references through `TaskDescription` in `iexec-sms`