### PR TITLE
Add no args constructors for Eip712 challenges, they are mandatory for feign clients

### DIFF
--- a/src/main/java/com/iexec/common/chain/eip712/EIP712Entity.java
+++ b/src/main/java/com/iexec/common/chain/eip712/EIP712Entity.java
@@ -20,15 +20,17 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ObjectArrays;
 import com.iexec.common.utils.HashUtils;
 import com.iexec.common.utils.SignatureUtils;
+import lombok.NoArgsConstructor;
 import org.web3j.crypto.ECKeyPair;
 
 import java.util.*;
 
+@NoArgsConstructor
 public abstract class EIP712Entity<M> implements EIP712<M> {
 
-    private final Map<String, List<TypeParam>> types;
-    private final EIP712Domain domain;
-    private final M message;
+    private Map<String, List<TypeParam>> types;
+    private EIP712Domain domain;
+    private M message;
 
     protected EIP712Entity(EIP712Domain domain, M message) {
         this.domain = domain;

--- a/src/main/java/com/iexec/common/result/eip712/Eip712Challenge.java
+++ b/src/main/java/com/iexec/common/result/eip712/Eip712Challenge.java
@@ -19,10 +19,12 @@ package com.iexec.common.result.eip712;
 import com.iexec.common.chain.eip712.EIP712Domain;
 import com.iexec.common.chain.eip712.EIP712Entity;
 import com.iexec.common.chain.eip712.TypeParam;
+import lombok.NoArgsConstructor;
 
 import java.util.Collections;
 import java.util.List;
 
+@NoArgsConstructor
 public class Eip712Challenge extends EIP712Entity<Message> {
     private static final String DOMAIN_NAME = "iExec Result Repository";
     private static final String DOMAIN_VERSION = "1";


### PR DESCRIPTION
This fix the following problem
```
org.springframework.http.converter.HttpMessageConversionException: Type definition error: [simple type, class com.iexec.common.result.eip712.Eip712Challenge]; nested exception is com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.iexec.common.result.eip712.Eip712Challenge` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
```