### PR TITLE
Unwrap AssertionErrors when needed

### DIFF
--- a/src/test/java/com/iexec/common/utils/ContextualLockRunnerTests.java
+++ b/src/test/java/com/iexec/common/utils/ContextualLockRunnerTests.java
@@ -3,7 +3,6 @@ package com.iexec.common.utils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -114,7 +113,7 @@ class ContextualLockRunnerTests {
      * operations will be separated in 2 blocks - odd and even keys -,
      * there should be at most 2 working threads at the same time.
      */
-    @RepeatedTest(1000)
+    @Test
     void acceptWithLockOnParity() {
         acceptWithLock(i -> i % 2 == 0);
         Assertions.assertThatThrownBy(() -> runWithoutLock(i -> i % 2 == 0))


### PR DESCRIPTION
`AssertionError`s are built in such a way there's sometimes a cause (~99%), sometimes not (~1%). This may cause some tests to fail.
The idea is to always unwrap these exceptions there, so that we're sure what we should test.