### PR TITLE
Feature/improve feign builders

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     api "io.github.openfeign:feign-jackson:$openFeignVersion"
     api "io.github.openfeign:feign-slf4j:$openFeignVersion"
 
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0"
+
     // multiaddresses (IPFS)
     implementation 'com.github.multiformats:java-multiaddr:1.3.1'
 

--- a/src/main/java/com/iexec/common/utils/FeignBuilder.java
+++ b/src/main/java/com/iexec/common/utils/FeignBuilder.java
@@ -2,6 +2,7 @@ package com.iexec.common.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.Feign;
 import feign.Logger;
 import feign.RequestTemplate;

--- a/src/main/java/com/iexec/common/utils/FeignBuilder.java
+++ b/src/main/java/com/iexec/common/utils/FeignBuilder.java
@@ -4,6 +4,7 @@ import feign.Feign;
 import feign.Logger;
 import feign.RequestTemplate;
 import feign.Response;
+import feign.auth.BasicAuthRequestInterceptor;
 import feign.codec.Encoder;
 import feign.codec.StringDecoder;
 import feign.jackson.JacksonDecoder;
@@ -76,6 +77,19 @@ public class FeignBuilder {
                 .logger(new Slf4jLogger())
                 .logLevel(logLevel)
                 .requestInterceptor(template -> template.header("Content-Type", "application/json"));
+    }
+
+    /**
+     * Returns a Feign builder configured with shared configurations and a {@code BasicAuthRequestInterceptor}.
+     * @param logLevel Feign logging level to configure.
+     * @param username Basic authentication username for authenticated REST calls.
+     * @param password Basic authentication password for authenticated REST calls.
+     * @return A Feign builder ready to implement a client by targeting an interface describing REST endpoints.
+     */
+    public static Feign.Builder createBuilder(Logger.Level logLevel, String username, String password) {
+        BasicAuthRequestInterceptor requestInterceptor =
+                new BasicAuthRequestInterceptor(username, password);
+        return createBuilder(logLevel).requestInterceptor(requestInterceptor);
     }
 
 }

--- a/src/main/java/com/iexec/common/utils/FeignBuilder.java
+++ b/src/main/java/com/iexec/common/utils/FeignBuilder.java
@@ -1,5 +1,7 @@
 package com.iexec.common.utils;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import feign.Feign;
 import feign.Logger;
 import feign.RequestTemplate;
@@ -45,7 +47,7 @@ import java.lang.reflect.Type;
  */
 public class FeignBuilder {
 
-    private FeignBuilder() {};
+    private FeignBuilder() {}
 
     /**
      * Returns a Feign builder configured with shared configurations.
@@ -53,8 +55,11 @@ public class FeignBuilder {
      * @return A Feign builder ready to implement a client by targeting an interface describing REST endpoints.
      */
     public static Feign.Builder createBuilder(Logger.Level logLevel) {
+        ObjectMapper mapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .build();
         return Feign.builder()
-                .encoder(new JacksonEncoder() {
+                .encoder(new JacksonEncoder(mapper) {
                     @Override
                     public void encode(Object object, Type bodyType, RequestTemplate template) {
                         if (bodyType == String.class) {
@@ -64,7 +69,7 @@ public class FeignBuilder {
                         }
                     }
                 })
-                .decoder(new JacksonDecoder() {
+                .decoder(new JacksonDecoder(mapper) {
                     @Override
                     public Object decode(Response response, Type type) throws IOException {
                         if (type == String.class) {

--- a/src/main/java/com/iexec/common/utils/FeignBuilder.java
+++ b/src/main/java/com/iexec/common/utils/FeignBuilder.java
@@ -92,7 +92,7 @@ public class FeignBuilder {
      * @param password Basic authentication password for authenticated REST calls.
      * @return A Feign builder ready to implement a client by targeting an interface describing REST endpoints.
      */
-    public static Feign.Builder createBuilder(Logger.Level logLevel, String username, String password) {
+    public static Feign.Builder createBuilderWithBasicAuth(Logger.Level logLevel, String username, String password) {
         BasicAuthRequestInterceptor requestInterceptor =
                 new BasicAuthRequestInterceptor(username, password);
         return createBuilder(logLevel).requestInterceptor(requestInterceptor);

--- a/src/test/java/com/iexec/common/config/PublicChainConfigTests.java
+++ b/src/test/java/com/iexec/common/config/PublicChainConfigTests.java
@@ -1,0 +1,59 @@
+package com.iexec.common.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidDefinitionException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class PublicChainConfigTests {
+
+    private final String errorMessage = "Java 8 date/time type `java.time.Duration` not supported by default";
+
+    @Test
+    void serializationShouldFailIfNoJavaTimeModule() {
+        ObjectMapper mapper = new ObjectMapper();
+        PublicChainConfig config = new PublicChainConfig();
+        config.setBlockTime(Duration.ofSeconds(5L));
+        config.setChainId(1);
+        config.setChainNodeUrl("http://localhost:8545");
+        config.setIexecHubContractAddress("0xabcd");
+        config.setSidechain(false);
+        assertThatThrownBy(() -> mapper.writeValueAsString(config))
+                .isInstanceOf(InvalidDefinitionException.class)
+                .hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    void deserializationShouldFailIfNoJavaTimeModule() {
+        ObjectMapper mapper = new ObjectMapper();
+        String jsonString = "{\"chainId\":1,\"chainNodeUrl\":\"http://localhost:8545\"," +
+                "\"iexecHubContractAddress\":\"0xabcd\",\"blockTime\":5.000000000,\"sidechain\":false}";
+        assertThatThrownBy(() -> mapper.readValue(jsonString, PublicChainConfig.class))
+                .isInstanceOf(InvalidDefinitionException.class)
+                .hasMessageContaining(errorMessage);
+    }
+
+    @Test
+    void shouldSerializeAndDeserializePublicChainConfig() throws JsonProcessingException {
+        ObjectMapper mapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .build();
+        PublicChainConfig refChainConfig = new PublicChainConfig();
+        refChainConfig.setBlockTime(Duration.ofSeconds(5L));
+        refChainConfig.setChainId(15);
+        refChainConfig.setChainNodeUrl("http://localhost:8545");
+        refChainConfig.setIexecHubContractAddress("0xabcd");
+        refChainConfig.setSidechain(true);
+        String jsonString = mapper.writeValueAsString(refChainConfig);
+        PublicChainConfig chainConfig = mapper.readValue(jsonString, PublicChainConfig.class);
+        assertThat(chainConfig).usingRecursiveComparison().isEqualTo(refChainConfig);
+    }
+
+}

--- a/src/test/java/com/iexec/common/utils/FeignBuilderTest.java
+++ b/src/test/java/com/iexec/common/utils/FeignBuilderTest.java
@@ -6,12 +6,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.socket.PortFactory;
 
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
@@ -55,7 +57,7 @@ public class FeignBuilderTest {
                 .respond(response()
                         .withBody("stringValue"));
         String value = feignTestClient.getStringValue();
-        Assertions.assertEquals("stringValue", value);
+        assertEquals("stringValue", value);
     }
 
     @Test
@@ -67,7 +69,7 @@ public class FeignBuilderTest {
                 .respond(response()
                         .withBody("")
                         .withStatusCode(200));
-        Assertions.assertEquals("", feignTestClient.setStringValue("stringValue"));
+        assertEquals("", feignTestClient.setStringValue("stringValue"));
     }
 
     @Test
@@ -77,9 +79,10 @@ public class FeignBuilderTest {
                         .withMethod("GET")
                         .withPath("/object"))
                 .respond(response()
-                        .withBody("{\"objectField\": \"objectValue\"}"));
+                        .withBody("{\"objectField\": \"objectValue\",\"durationField\":5.000000000}"));
         TestObject testObject = feignTestClient.getTestObject();
-        Assertions.assertEquals("objectValue", testObject.getObjectField());
+        assertEquals("objectValue", testObject.getObjectField());
+        assertEquals(Duration.ofSeconds(5L), testObject.getDurationField());
     }
 
     @Test
@@ -93,7 +96,8 @@ public class FeignBuilderTest {
                         .withStatusCode(200));
         TestObject testObject = new TestObject();
         testObject.setObjectField("objectValue");
-        Assertions.assertEquals("", feignTestClient.setTestObject(testObject));
+        testObject.setDurationField(Duration.ofSeconds(5));
+        assertEquals("", feignTestClient.setTestObject(testObject));
     }
 
     interface FeignTestClient {
@@ -117,6 +121,7 @@ public class FeignBuilderTest {
     @NoArgsConstructor
     static class TestObject {
         private String objectField;
+        private Duration durationField;
     }
 
 }

--- a/src/test/java/com/iexec/common/utils/FeignBuilderTest.java
+++ b/src/test/java/com/iexec/common/utils/FeignBuilderTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.socket.PortFactory;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
@@ -35,6 +36,14 @@ public class FeignBuilderTest {
     @AfterEach
     void stopServer() {
         mockServer.stop();
+    }
+
+    @Test
+    void testBuilderCreation() {
+        assertNotNull(FeignBuilder.createBuilder(Logger.Level.FULL)
+                .target(FeignTestClient.class, "http://localhost:" + mockServer.getPort()));
+        assertNotNull(FeignBuilder.createBuilder(Logger.Level.FULL, "username", "password")
+                .target(FeignTestClient.class, "http://localhost:" + mockServer.getPort()));
     }
 
     @Test

--- a/src/test/java/com/iexec/common/utils/FeignBuilderTest.java
+++ b/src/test/java/com/iexec/common/utils/FeignBuilderTest.java
@@ -42,7 +42,7 @@ public class FeignBuilderTest {
     void testBuilderCreation() {
         assertNotNull(FeignBuilder.createBuilder(Logger.Level.FULL)
                 .target(FeignTestClient.class, "http://localhost:" + mockServer.getPort()));
-        assertNotNull(FeignBuilder.createBuilder(Logger.Level.FULL, "username", "password")
+        assertNotNull(FeignBuilder.createBuilderWithBasicAuth(Logger.Level.FULL, "username", "password")
                 .target(FeignTestClient.class, "http://localhost:" + mockServer.getPort()));
     }
 


### PR DESCRIPTION
Add feign builder with BasicAuthRequestInterceptor.
Add JSR310 support by defining a custom `ObjectMapper` configured with `JavaTimeModule`.
This support allows to serialize and deserialize fields of `java.time.Duration` type in `PubliCainConfig`.