### PR TITLE
fix: deprecate unused fields in `ResultModel`, covering data existing on-chain

### DIFF
--- a/src/main/java/com/iexec/common/result/ResultModel.java
+++ b/src/main/java/com/iexec/common/result/ResultModel.java
@@ -39,7 +39,9 @@ public class ResultModel {
     String dealId = EMPTY_HEX_STRING_32;
     @Builder.Default
     int taskIndex = 0;
+    @Deprecated(forRemoval = true)
     String image;
+    @Deprecated(forRemoval = true)
     String cmd;
     @Builder.Default
     byte[] zip = new byte[0];

--- a/src/test/java/com/iexec/common/result/ResultModelTests.java
+++ b/src/test/java/com/iexec/common/result/ResultModelTests.java
@@ -28,20 +28,37 @@ class ResultModelTests {
 
     private static final ObjectMapper mapper = new ObjectMapper();
 
+    // TODO to remove when deprecated fields are removed
+    @Test
+    void shouldDeserializeJsonWithOnlyValidFields() throws JsonProcessingException {
+        final String jsonString = "{\"chainTaskId\":\"" + EMPTY_HEX_STRING_32 + "\"," +
+                "\"dealId\":\"" + EMPTY_HEX_STRING_32 + "\",\"taskIndex\":0," +
+                "\"zip\":\"\",\"deterministHash\":null," +
+                "\"enclaveSignature\":\"" + EMPTY_WEB3_SIG + "\"}";
+        final ResultModel expectedResultModel = ResultModel.builder().build();
+        final ResultModel parsedResultModel = mapper.readValue(jsonString, ResultModel.class);
+        assertThat(parsedResultModel).usingRecursiveComparison().isEqualTo(expectedResultModel);
+        assertThat(parsedResultModel).hasToString(
+                "ResultModel(chainTaskId=" + EMPTY_HEX_STRING_32 + ", dealId=" + EMPTY_HEX_STRING_32 +
+                        ", taskIndex=0, image=null, cmd=null, zip=[]" +
+                        ", deterministHash=null, enclaveSignature=" + EMPTY_WEB3_SIG + ")"
+        );
+    }
+
     @Test
     void shouldSerializeAndDeserialize() throws JsonProcessingException {
-        ResultModel resultModel = ResultModel.builder().build();
-        String jsonString = mapper.writeValueAsString(resultModel);
+        final ResultModel resultModel = ResultModel.builder().build();
+        final String jsonString = mapper.writeValueAsString(resultModel);
         assertThat(jsonString).isEqualTo("{\"chainTaskId\":\"" + EMPTY_HEX_STRING_32 + "\"," +
-                "\"dealId\":\"" + EMPTY_HEX_STRING_32 + "\",\"taskIndex\":0" +
-                ",\"image\":null,\"cmd\":null,\"zip\":\"\",\"deterministHash\":null," +
+                "\"dealId\":\"" + EMPTY_HEX_STRING_32 + "\",\"taskIndex\":0," +
+                "\"image\":null,\"cmd\":null,\"zip\":\"\",\"deterministHash\":null," +
                 "\"enclaveSignature\":\"" + EMPTY_WEB3_SIG + "\"}");
         ResultModel parsedResultModel = mapper.readValue(jsonString, ResultModel.class);
         assertThat(parsedResultModel).usingRecursiveComparison().isEqualTo(resultModel);
-        assertThat(resultModel).hasToString(
+        assertThat(parsedResultModel).hasToString(
                 "ResultModel(chainTaskId=" + EMPTY_HEX_STRING_32 + ", dealId=" + EMPTY_HEX_STRING_32 +
-                        ", taskIndex=0" + ", image=null, cmd=null, zip=[]"
-                        + ", deterministHash=null, enclaveSignature=" + EMPTY_WEB3_SIG + ")"
+                        ", taskIndex=0, image=null, cmd=null, zip=[]" +
+                        ", deterministHash=null, enclaveSignature=" + EMPTY_WEB3_SIG + ")"
         );
     }
 }


### PR DESCRIPTION
An unit test has been added to verify a JSON which does not contain the deprecated fields will be successfully deserialized in Java.